### PR TITLE
escape symbol

### DIFF
--- a/teamcity-reporter.js
+++ b/teamcity-reporter.js
@@ -21,7 +21,7 @@ module.exports = function(errorsCollection) {
         errorCount++;
         console.log(util.format(
           '##teamcity[testFailed name=\'%s\' message=\'line %d, col %d, %s\']',
-          file, error.line, error.column, error.message));
+          file, error.line, error.column, error.message.replace('\'', '|\'')));
       });
       console.log(util.format('##teamcity[testFinished name=\'%s\']', file));
     }


### PR DESCRIPTION
fix for TeamCity error log:

```
[08:21:25][JSCS] ./admin/lib/utils/server/profiler.js
[08:21:25][./admin/lib/utils/server/profiler.js] ##teamcity[testFailed name='./admin/lib/utils/server/profiler.js' message='line 5, col 4, 'return' outside of function (5:4)']
[08:21:25][./admin/lib/utils/server/profiler.js] Property value not found Valid property list format is (name( )*=( )*'escaped_value'( )*)* where escape symbol is "|"
```
